### PR TITLE
Additional Initialization parameter

### DIFF
--- a/man/SvmNucleusCaller.Rd
+++ b/man/SvmNucleusCaller.Rd
@@ -12,6 +12,7 @@ SvmNucleusCaller(
   featureColumns = NULL,
   forceTwoClusterSolution = FALSE,
   useCBRBFeatures = TRUE,
+  useCBRBInitialization = useCBRBFeatures,
   datasetName = ""
 )
 }
@@ -50,6 +51,11 @@ false.}
 is used for cell selection. When false, these features are not used.  This
 modifies the featureColumns argument.}
 
+\item{useCBRBInitialization}{When true, the cellbender feature
+frac_contamination is used to select exemplar nuclei and empty droplets.
+This option can be false and useCBRBFeatures to force DropSift to use the
+non-CBRB initialization but still include CBRB in the model features.}
+
 \item{datasetName}{A string to identify the dataset in plots.}
 }
 \value{
@@ -70,6 +76,7 @@ svmNucleusCaller <- SvmNucleusCaller(
     dgeMatrix = svmNucleusCallerInputs$dgeMatrix,
     datasetName = "example_dataset",
     useCBRBFeatures = FALSE,
+    useCBRBInitialization=FALSE,
     forceTwoClusterSolution = FALSE
 )
 # View summary

--- a/man/runIntronicSVM.Rd
+++ b/man/runIntronicSVM.Rd
@@ -13,6 +13,7 @@ runIntronicSVM(
   max_umis_empty = 50,
   features = NULL,
   useCBRBFeatures = TRUE,
+  useCBRBInitialization = useCBRBFeatures,
   forceTwoClusterSolution = FALSE,
   outPDF = NULL,
   outFeaturesFile = NULL,
@@ -58,6 +59,11 @@ generated from the gene expression data.}
 \item{useCBRBFeatures}{When true, the cell bender feature frac_contamination
 is used for cell selection. When false, these features are not used.  This
 modifies the features argument.}
+
+\item{useCBRBInitialization}{When true, the cellbender feature
+frac_contamination is used to select exemplar nuclei and empty droplets.
+This option can be false and useCBRBFeatures to force DropSift to use the
+non-CBRB initialization but still include CBRB in the model features.}
 
 \item{forceTwoClusterSolution}{When true, the initialization of the SVM will
 attempt to find a solution with two clusters. In cases where an experiment


### PR DESCRIPTION
Added parameter to DropSift to allow more control over how initialization occurs.  By default, if cellbender data is provided that is used to select initial empty/nuclei exemplars.  New parameter allows that behavior to be overridden and use the more complicated initialization based on density of the log (UMI) and % intronic metrics.  This can be useful in cases where the amount of debris in the experiment is high and cellbender marks the debris as not empty.